### PR TITLE
Refactor with new processModule function

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ the following example statement and subsequent output.
 
 ```bash
 bun run index.ts -n linkedom
-[INFO]: Found dependency list: linkedom@0.16.8,cssom@0.5.0,css-select@5.1.0,html-escaper@3.0.3,htmlparser2@9.1.0,uhyphen@0.2.0,boolbase@1.0.0,css-what@6.1.0,nth-check@2.1.1,domutils@3.1.0,domelementtype@2.3.0,domhandler@5.0.3,entities@4.5.0,dom-serializer@2.0.0
-[WARN]: Additional module entities_decode needs be manually downloaded: https://cdn.jsdelivr.net/npm/entities@4.5.0/lib/decode.js/+esm
-[INFO]: Run /tmp/linkedom-TfVoIc/install.sql in SQLcl to compile MLE objects to the database.
+[INFO]: Found dependency list: linkedom@0.16.8,html-escaper@3.0.3,htmlparser2@9.1.0,cssom@0.5.0,css-select@5.1.0,uhyphen@0.2.0,domhandler@5.0.3,domelementtype@2.3.0,domutils@3.1.0,entities@4.5.0,boolbase@1.0.0,css-what@6.1.0,nth-check@2.1.1,dom-serializer@2.0.0
+[INFO]: Run /tmp/linkedom-FzZN8E/install.sql in SQLcl to compile MLE objects to the database.
 ```
 
 As outlined here, there are some packages that might not be picked up - such as  

--- a/README.md
+++ b/README.md
@@ -22,17 +22,11 @@ bun run index.ts -n linkedom
 [INFO]: Run /tmp/linkedom-FzZN8E/install.sql in SQLcl to compile MLE objects to the database.
 ```
 
-As outlined here, there are some packages that might not be picked up - such as  
-the `entities` package contains a separate module path (as you see in the above  
-output). The intention is to handle this, but we're not there yet.
-
 If you navigate to the temporary folder that was printed out on the last line of  
 output, you will find a bunch of SQL scripts:
 
-1. _install.sql - designed to run all the generated SQL files
-2. _remove.sql - wind back, removing all that was created
-3. All the modules in SQL files
-4. The environment which specifies all the import modules
-
-**important note:** Depending on the characters in the script, they may not compile  
-correctly, and will require some manual intervention to tidy things up.
+1. install.sql - designed to run all the generated SQL files
+2. remove.sql - wind back, removing all that was created
+3. moduleLoader.js - JavaScript code that can be run in SQLcl that loads data to a table
+4. All the modules JS - replacing module references so they are imported correctly
+5. The environment which specifies all the import modules

--- a/index.ts
+++ b/index.ts
@@ -186,9 +186,6 @@ async function processModule({
       // overrides was specified in this file - and we need to track that in our
       // module imports/environment
       if (originalModuleText != moduleText){
-        // TODO: Restructure the program so we can handle the fetch of this
-        // additional module
-        logger.warn(`Additional module ${override.moduleName} needs be manually downloaded: https://cdn.jsdelivr.net/npm/${substitutePackageInfo.originalName}@${substitutePackageInfo.version}${override.relativePath}`);
         await processModule({
           moduleName: override.moduleName,
           originalModuleName: substitutePackageInfo.originalName,
@@ -204,8 +201,6 @@ async function processModule({
           allUnreplacedModules
         });
       }
-
-
     }
   }
 

--- a/index.ts
+++ b/index.ts
@@ -52,6 +52,7 @@ async function getDependencies(moduleName: string): Promise<string[]>{
 
   // The output of the command quotes using single quotes instead of double quotes
   // which is not valid JSON, so we need to replace `'` with `"`
+  logger.info(`Command output: ${procStdOut}`)
   const packageList: string[] = JSON.parse(procStdOut.replace(/'/g, '"'));
   forcedInfo(`Found dependency list: ${packageList}`);
 

--- a/index.ts
+++ b/index.ts
@@ -14,7 +14,7 @@ import { logger, forcedInfo } from "./logger";
 const additionalModulePaths = {
   "entities": [
     {
-      "relativePath": "/lib/decode.js/+esm",
+      "relativePath": "lib/decode.js/+esm",
       "moduleName": "entities_decode"
     }
   ]


### PR DESCRIPTION
The restructure now means additional libraries not in the official dependency list can be picked up (if defined in our overries structure).

Example being the entities library - which has a secondary decode module, via a separate file.